### PR TITLE
Add JSON Endpoints

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,6 +73,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-20
+  x86_64-darwin-23
   x86_64-linux
 
 DEPENDENCIES

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -10,6 +10,13 @@
   <script src="https://code.highcharts.com/maps/modules/data.js"></script>
   <script type="text/javascript" src="{{ "/assets/js/bundle.js" | relative_url }}"></script>
 
+  <!-- URLs for json endpoints -->
+  <link rel="alternate" title="{{ site.title }}" type="application/json" href="{{ "/feed-newsletters.json" | absolute_url }}" />
+  <link rel="alternate" title="{{ site.title }}" type="application/json" href="{{ "/feed-articles.json" | absolute_url }}" />
+  <link rel="alternate" title="{{ site.title }}" type="application/json" href="{{ "/feed-resources.json" | absolute_url }}" />
+  <link rel="alternate" title="{{ site.title }}" type="application/json" href="{{ "/feed-goals.json" | absolute_url }}" />
+  <!-- End URLs for json endpoints -->
+
   <link rel="icon" sizes="192x192" href="{{ '/assets/img/android-chrome-192x192.png' | relative_url }}" />
   <link rel="apple-touch-icon" sizes="180x180" href="{{ '/assets/img/apple-touch-icon.png' | relative_url }}" />
   <link rel="icon" type="image/png" href="{{ '/assets/img/favicon-32x32.png' | relative_url }}" sizes="32x32" />

--- a/feed-articles.json
+++ b/feed-articles.json
@@ -1,0 +1,24 @@
+---
+layout: null
+---
+{
+    "title": "Engaging Indian States: Articles",
+    "items": [
+        {% for post in site.posts %}
+        {
+            "resource_type": "article",
+            "headline": {{ post.title | jsonify }},
+            "date": "{{ post.date | date_to_xmlschema }}",
+            "date_month": "{{ post.date | date: "%b" }}",
+            "date_day": "{{ post.date | date: "%d" }}",
+            "date_year": "{{ post.date | date: "%Y" }}",
+            "content": {{ post.content | jsonify }},
+            "states": {% assign state_list = post.states | split: ", " %}{% for state in state_list %}{{ state }}{% unless forloop.last %}, {% endunless %}{% endfor %},
+            "sectors": {% assign sector_list = post.sectors | split: ", " %}{% for sector in sector_list %}{{ sector }}{% unless forloop.last %}, {% endunless %}{% endfor %},
+            "subsectors": {% assign subsector_list = post.subsectors | split: ", " %}{% for subsector in subsector_list %}{{ subsector }}{% unless forloop.last %}, {% endunless %}{% endfor %},
+            "url": "{{ post.url | absolute_url }}",
+            "primary_sources": {{ post.sources | jsonify }},
+        }{% if forloop.last == false %},{% endif %}
+        {% endfor %}
+    ]
+}

--- a/feed-goals.json
+++ b/feed-goals.json
@@ -1,0 +1,23 @@
+---
+layout: null
+---
+{
+    "title": "Engaging Indian States: Goals",
+    "items": [
+        {% for goal in site.national-goals %}
+        {
+            "resource_type": "goal",
+            "headline": {{ goal.title | jsonify }},
+            "sectors": {% assign sector_list = goal.sectors | split: ", " %}{% for sector in sector_list %}{{ sector }}{% unless forloop.last %}, {% endunless %}{% endfor %},
+            "subsectors": {% assign subsector_list = goal.subsectors | split: ", " %}{% for subsector in subsector_list %}{{ subsector }}{% unless forloop.last %}, {% endunless %}{% endfor %},
+            "date": "{{ goal.last_updated_at | date_to_xmlschema }}",
+            "date_month": "{{ goal.last_updated_at | date: "%b" }}",
+            "date_day": "{{ goal.last_updated_at | date: "%d" }}",
+            "date_year": "{{ goal.last_updated_at | date: "%Y" }}",
+            "content": {{ goal.content | markdownify | strip_html | strip_newlines | jsonify }},
+            "url": "{{ goal.url | absolute_url }}",
+            "primary_sources": {{ goal.sources | jsonify }},
+        }{% if forloop.last == false %},{% endif %}
+        {% endfor %}
+    ]
+}

--- a/feed-newsletters.json
+++ b/feed-newsletters.json
@@ -1,0 +1,27 @@
+---
+layout: null
+---
+{
+    "title": "Engaging Indian States: Newsletters",
+    "items": [
+        {% for post in site.analysis %}
+        {
+            "resource_type": "newsletter",
+            "headline": {{ post.title | jsonify }},
+            "date": "{{ post.date | date_to_xmlschema }}",
+            "date_month": "{{ post.date | date: "%b" }}",
+            "date_day": "{{ post.date | date: "%d" }}",
+            "date_year": "{{ post.date | date: "%Y" }}",
+            "excerpt": {{ post.excerpt | strip_html | strip_newlines | jsonify }},
+            "tags": {% assign tags_list = post.tags | split: ", " %}{% for tag in tags_list %}{{ tag }}{% unless forloop.last %}, {% endunless %}{% endfor %},
+            "states": {% assign state_list = post.states | split: ", " %}{% for state in state_list %}{{ state }}{% unless forloop.last %}, {% endunless %}{% endfor %},
+            "sectors": {% assign sector_list = post.sectors | split: ", " %}{% for sector in sector_list %}{{ sector }}{% unless forloop.last %}, {% endunless %}{% endfor %},
+            "subsectors": {% assign subsector_list = post.subsectors | split: ", " %}{% for subsector in subsector_list %}{{ subsector }}{% unless forloop.last %}, {% endunless %}{% endfor %},
+            "is_featured": {{ post.is_featured }},
+            "url": "{{ post.url | absolute_url }}",
+            "primary_sources": {{ post.sources | jsonify }},
+            "author": {% assign author_list = post.author | split: ", " %}{% for author in author_list %}{{ author }}{% unless forloop.last %}, {% endunless %}{% endfor %},
+        }{% if forloop.last == false %},{% endif %}
+        {% endfor %}
+    ]
+}

--- a/feed-resources.json
+++ b/feed-resources.json
@@ -1,0 +1,21 @@
+---
+layout: null
+---
+{
+    "title": "Engaging Indian States: Resources",
+    "items": [
+        {% for resource in site.resources %}
+        {
+            "resource_type": "resource",
+            "headline": {{ resource.title | jsonify }},
+            "url": "{{ resource.link | absolute_url }}",
+            "author": {% assign author_list = resource.author | split: ", " %}{% for author in author_list %}{{ author }}{% unless forloop.last %}, {% endunless %}{% endfor %},
+            "content": {{ resource.summary | jsonify }},
+            "date": "{{ resource.posted_on | date_to_xmlschema }}",
+            "date_month": "{{ resource.posted_on | date: "%b" }}",
+            "date_day": "{{ resource.posted_on | date: "%d" }}",
+            "date_year": "{{ resource.posted_on | date: "%Y" }}",
+        }{% if forloop.last == false %},{% endif %}
+        {% endfor %}
+    ]
+}


### PR DESCRIPTION
## Description

Create 4 `json` endpoints for the table to consume (related to Issue #40) - one each for newsletters, goals, articles, and resources. The data in each matches the data in the associated content's front-matter. 

To make things easier for us later:
* The key for the title is "headline" since that's what it's called in the table design
* The date is pulled, but it's also split into month, day, and year to make sorting easier 
* The month is pulled as the 3 letter abbreviation, since that's how it is in the table design (e.g. Mar instead of March)
* Where multiple values are possible, you'll get back an array (e.g. array of states, authors, etc)
* The files reflect the resource types they supply for the table. Instead of "analysis", we have newsletters. 
* Newsletters include tags so we can grab the States Quarterly (states weekly may require us parsing the name, I didn't see a tag for them)

## Screenshots
### Goals
<img width="934" alt="goals" src="https://github.com/CSIS-iLab/india-states-v2/assets/41589348/51a163c3-a176-4f5d-914e-d7249c7afb34">

### Resources
<img width="938" alt="resources" src="https://github.com/CSIS-iLab/india-states-v2/assets/41589348/f159274a-bc15-420b-ad31-c5f817e9bf99">

### Newsletters
<img width="918" alt="newsletters" src="https://github.com/CSIS-iLab/india-states-v2/assets/41589348/33adb293-aada-44c5-a99d-c089bc74214e">

### Articles
<img width="946" alt="articles" src="https://github.com/CSIS-iLab/india-states-v2/assets/41589348/7397f18b-c3d4-4948-82c2-aec36acab6a8">

## Future Steps
This does not close out #40 - this is only a part of how we'd get the data to the table. Right now (1/11/24) we are leaning toward using an iframe to get the table into the site (i.e. have the table at a different domain), so we need to
* Figure out how the table will pull in this content 
* Once that is working: solve communicating between the site's nav bar and the table's filters (between a window and an iframe it contains)